### PR TITLE
converted sub bugfix part 2

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    style="width: 100%; height: 100%; position: relative"
-    id="videoPlayerContainer"
-  >
+  <div style="width: 100%; height: 100%; position: relative" id="videoPlayerContainer">
     <VideoOSD />
   </div>
 </template>
@@ -359,16 +356,21 @@ export default {
         );
         return;
       }
-      const subtitleSuccess = await applySubtitles(
+      applySubtitles(
         videoElement,
         this.server.publicAddress,
         this.playbackInfo,
         subTrack
-      );
-      if (subtitleSuccess) {
-        this.subsReady = true;
-        console.log("Subtitles are ready");
-      }
+      ).then(() => {
+        console.log("Subtitles loaded successfully");
+      })
+        .catch((err) => {
+          console.error("Error applying subtitles:", err);
+        })
+        .finally(() => {
+          // just set it to be true regardless of what happens so we can display subs even if a non-fatal error occurs
+          this.subsReady = true;
+        });
     },
   },
   computed: {


### PR DESCRIPTION
it seems like it was getting a non-fatal error when loading the converted subs which copilot says is fine to ignore but i believe the way it was set up it only ever set subsReady = true when we get through that applySubtitles method without any errors so i reworked it to always set subsReady to true after it finishes

i think this is still fine since we only set subsReady to true after applySubtitles is complete and even if we do run into an actual fatal error with applying subs then just setting subsReady to true would likely only result in subs not showing up on the screen (which would be expected if we ran into a fatal error when applyingSubtitles)